### PR TITLE
Handle missing body field

### DIFF
--- a/asana_outlook_integration_script.py
+++ b/asana_outlook_integration_script.py
@@ -227,6 +227,10 @@ def main():
         msgs = data.get("value", [])
 
         for msg in msgs:
+            # Skip any message where Graph didn’t return a body field
+            if 'body' not in msg:
+                logger.warning(f"Skipping message {msg.get('id')}\u2014no body returned")
+                continue
             mid = msg.get("id")
             if mid in done:
                 continue


### PR DESCRIPTION
## Summary
- guard against Graph messages that don't contain a `body` field

## Testing
- `python -m py_compile asana_outlook_integration_script.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68654f1a0ff0832f8abb2dd9aa0d6419