### PR TITLE
Add HTML sanitization and subject-based routing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ msal>=1.20
 requests>=2.28
 asana>=1.0
 python-dotenv>=1.0
+beautifulsoup4>=4.11.1


### PR DESCRIPTION
## Summary
- sanitize HTML bodies with BeautifulSoup
- add optional Asana section IDs
- route tasks to sections based on subject
- include BeautifulSoup dependency

## Testing
- `python -m py_compile asana_outlook_integration_script.py`
- `pip install -q -r requirements.txt`
- `python main.py --help` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_686597de6030832fa9e928dae50ce381