### PR TITLE
Fix section payload for Asana API

### DIFF
--- a/asana_outlook_integration_script.py
+++ b/asana_outlook_integration_script.py
@@ -193,7 +193,13 @@ def process_message(msg, tasks_api, attach_api, sections_api, location, job_num,
     # Add the task to the chosen section
     sections_api.add_task_for_section(
         section_gid,
-        {"data": {"task": gid}}
+        {
+            "body": {
+                "data": {
+                    "task": gid
+                }
+            }
+        }
     )
 
     # update custom fields


### PR DESCRIPTION
## Summary
- update call to `add_task_for_section` to wrap payload in a `body` key

## Testing
- `python -m py_compile asana_outlook_integration_script.py`


------
https://chatgpt.com/codex/tasks/task_e_6865a2d7cc10832fae4df11ec1c2f2fa