### PR TITLE
Fix attachments API call

### DIFF
--- a/asana_outlook_integration_script.py
+++ b/asana_outlook_integration_script.py
@@ -254,7 +254,11 @@ def process_message(msg, tasks_api, attach_api, sections_api, location, job_num,
         with open(local, "wb") as f:
             f.write(r.content)
         with open(local, "rb") as f:
-            attach_api.create_attachment_on_task(gid, f, {})
+            attach_api.create_attachment_for_object(
+                "tasks",
+                gid,
+                {"file": f}
+            )
         os.remove(local)
 
 


### PR DESCRIPTION
## Summary
- use Asana client's `create_attachment_for_object` when uploading attachments
- verify Matrix rain effect

## Testing
- `pip install -r requirements.txt`
- `python asana_outlook_integration_script.py` *(fails: ProxyError to `login.microsoftonline.com`)*

------
https://chatgpt.com/codex/tasks/task_e_6866ae8f5b18832fa233c06b8f6aaf21