### PR TITLE
Add colorama and enhanced main output

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,31 @@
+import sys
+import io
+import traceback
+from colorama import init as _colorama_init, Fore
 from asana_outlook_integration_script import main as run
 
+_colorama_init()
+
+def main_wrapper():
+    # Capture all stdout/stderr
+    old_out, old_err = sys.stdout, sys.stderr
+    buf = io.StringIO()
+    sys.stdout, sys.stderr = buf, buf
+    try:
+        print("Starting main.py execution")
+        run()
+        print("Script completed")
+    except Exception:
+        buf.write(traceback.format_exc())
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+    output = buf.getvalue()
+    # Convert each character to 8-bit binary
+    binary = " ".join(format(ord(c), "08b") for c in output)
+    # Print binary in green, then original text
+    print(Fore.GREEN + binary)
+    print(output)
+
 if __name__ == "__main__":
-    # simple prints ensure logs appear in GitHub Actions
-    print("Starting main.py execution")
-    run()
-    print("Script completed")
+    main_wrapper()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.28
 asana>=1.0
 python-dotenv>=1.0
 beautifulsoup4>=4.11.1
+colorama>=0.4.6


### PR DESCRIPTION
## Summary
- include colorama in requirements
- capture script output in `main.py`, print in binary (green) then replay normal text

## Testing
- `pip install -r requirements.txt`
- `python main.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866b221ca98832fa9539ce2501865ea