### PR TITLE
Update attach call and live binary streaming

### DIFF
--- a/asana_outlook_integration_script.py
+++ b/asana_outlook_integration_script.py
@@ -255,10 +255,12 @@ def process_message(msg, tasks_api, attach_api, sections_api, location, job_num,
         with open(local, "wb") as f:
             f.write(r.content)
         with open(local, "rb") as f:
-            attach_api.create_attachment_for_object(
+            # Use the HTTP-info version which accepts (object_type, object_gid, opts, **kwargs)
+            attach_api.create_attachment_for_object_with_http_info(
                 "tasks",
                 gid,
-                {"file": f}
+                {"file": f},
+                {}
             )
         os.remove(local)
 

--- a/main.py
+++ b/main.py
@@ -1,31 +1,41 @@
-import sys
-import io
-import traceback
+import sys, io, traceback
 from colorama import init as _colorama_init, Fore
 from asana_outlook_integration_script import main as run
 
 _colorama_init()
 
+class BinaryWriter:
+    """Wraps a real stream, writing every incoming chunk as green 8-bit binary."""
+    def __init__(self, real):
+        self.real = real
+    def write(self, s):
+        if not s:
+            return
+        # Convert each character to binary and output in green
+        bits = " ".join(format(ord(ch), "08b") for ch in s)
+        self.real.write(Fore.GREEN + bits + "\n")
+    def flush(self):
+        self.real.flush()
+
 def main_wrapper():
-    # Capture all stdout/stderr
+    # Swap out stdout/stderr for live binary streaming
     old_out, old_err = sys.stdout, sys.stderr
-    buf = io.StringIO()
-    sys.stdout, sys.stderr = buf, buf
+    bin_out = BinaryWriter(old_out)
+    sys.stdout = sys.stderr = bin_out
     try:
         print("Starting main.py execution")
         run()
         print("Script completed")
     except Exception:
-        buf.write(traceback.format_exc())
+        traceback.print_exc()
     finally:
         sys.stdout, sys.stderr = old_out, old_err
 
-    output = buf.getvalue()
-    # Convert each character to 8-bit binary
-    binary = " ".join(format(ord(c), "08b") for c in output)
-    # Print binary in green, then original text
-    print(Fore.GREEN + binary)
-    print(output)
+    # restore real streams, capture traceback if any
+    sys.stdout, sys.stderr = old_out, old_err
+    print("\n\n=== Run complete. Final logs / traceback below ===\n")
+    # Now replay the captured text so you can read it
+    print(bin_out.real.getvalue() if hasattr(bin_out.real, "getvalue") else "")
 
 if __name__ == "__main__":
     main_wrapper()


### PR DESCRIPTION
## Summary
- use Asana `create_attachment_for_object_with_http_info`
- live-stream binary output from main wrapper

## Testing
- `python -m py_compile main.py asana_outlook_integration_script.py`
- `python main.py` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6866b6f08f1c832fb067e8172f13b968