### PR TITLE
Annotate emails with folder metadata and analyze attachment text

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ matplotlib>=3.5
 scikit-learn>=1.2
 nltk>=3.8
 textblob>=0.17
+pdfminer.six>=20221105
+python-docx>=0.8.11


### PR DESCRIPTION
## Summary
- Capture Outlook folder hierarchy to tag messages with year, location, and job number.
- Extract text from PDF and DOCX attachments and merge with email bodies for sentiment and topic modeling.
- Add required pdfminer.six and python-docx dependencies.

## Testing
- `pip install pdfminer.six python-docx`
- `python -m py_compile email_analytics.py`


------
https://chatgpt.com/codex/tasks/task_e_689356b19718832f8024e08425761a07