### PR TITLE
Add attachment OCR and job folder mapping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ nltk>=3.8
 textblob>=0.17
 pdfminer.six>=20240524
 python-docx>=0.8.11
+openpyxl>=3.1.2
+pillow>=11.0.0
+pytesseract>=0.3.10


### PR DESCRIPTION
## Summary
- Search the user's mailbox for a `2024 Jobs` root folder and map folder paths.
- Collect messages from that folder, including conversation threading and attachments.
- Extract text from PDFs, Word, Excel and image attachments (OCR) and combine with email body for analysis.

## Testing
- `python -m py_compile email_analytics.py`
- `python - <<'PY'
import openpyxl, pytesseract
from PIL import Image
from pdfminer.high_level import extract_text_to_fp
from docx import Document
print('imports ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6893676ea6a0832fb78dee95d1bdd3e2