### PR TITLE
Expose sender address in analytics data

### DIFF
--- a/email_analytics.py
+++ b/email_analytics.py
@@ -163,6 +163,13 @@ def fetch_inbox_messages():
             att_resp.raise_for_status()
             m["attachments"] = att_resp.json().get("value", [])
 
+            # extract the sender address into its own field
+            m["sender"] = (
+                m.get("from", {})
+                .get("emailAddress", {})
+                .get("address", "")
+            )
+
             all_msgs.append(m)
         next_link = data.get("@odata.nextLink")
 
@@ -171,12 +178,10 @@ def fetch_inbox_messages():
 # ─── Build DataFrame ─────────────────────────────────────────────────────────────────────────
 msgs = fetch_inbox_messages()
 df = pd.DataFrame(msgs)
-df["sender"] = df["from"].apply(lambda f: f.get("emailAddress", {}).get("address"))
 df["receivedDateTime"] = pd.to_datetime(df["receivedDateTime"])
 df = df[[
     "id",
     "subject",
-    "from",
     "sender",
     "receivedDateTime",
     "bodyPreview",


### PR DESCRIPTION
## Summary
- include a `sender` field when fetching messages
- build analytics DataFrame using the `sender` field and drop unused `from`

## Testing
- `python -m py_compile *.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893709b8750832fa36f927d1c62e3f5