### PR TITLE
Introduce async email analytics with sentiment & MDP

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+
+
+class EmailAttachment(BaseModel):
+    name: str
+    contentType: Optional[str] = None
+    mediaReadLink: Optional[str] = Field(None, alias='@odata.mediaReadLink')
+
+
+class EmailMessage(BaseModel):
+    id: str
+    subject: str
+    sender: Dict[str, Any] = Field(alias='from')
+    receivedDateTime: str
+    conversationId: Optional[str]
+    parentFolderId: Optional[str]
+    body: Dict[str, Any]
+    attachments: List[EmailAttachment] = []
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
 msal>=1.20
 requests>=2.28
 asana>=1.0
+pydantic>=1.10.0
+httpx>=0.24.0
+tenacity>=8.2.2
+structlog>=23.1.0
+transformers>=4.30.0
+pymdptoolbox>=4.11
 python-dotenv>=1.0
 beautifulsoup4>=4.11.1
 colorama>=0.4.6


### PR DESCRIPTION
## Summary
- extend dependencies for async processing and ML
- add Pydantic models for email data
- rebuild email analytics with async Graph fetch, transformer sentiment, and MDP policy logging

## Testing
- `python -m py_compile models.py email_analytics.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68938131bcb0832fa132020bc664f066