### PR TITLE
feat: add modern async email analytics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ python-docx>=0.8.11
 openpyxl>=3.1.2
 pillow>=11.0.0
 pytesseract>=0.3.10
+toml>=0.10.2
+numpy>=1.23
+hdbscan>=0.8


### PR DESCRIPTION
## Summary
- overhaul email_analytics into async pipeline with paging, retries, and pydantic models
- embed and cluster emails via transformers + HDBSCAN
- record provenance and add dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689384141d28832fb6a7393e67b4fa4a