### PR TITLE
Add auth_mode option for Graph token acquisition

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ from `.env` (or the path specified by `ENV_FILE`).
 `email_analytics.py` retrieves messages from an Outlook Inbox using the Microsoft Graph API and performs basic analytics such as sender counts, sentiment analysis, and topic modeling.
 
 1. Ensure the dependencies in `requirements.txt` are installed.
-2. Populate `.env` (or `config.toml`) with your Azure AD details. The script expects:
-   `AZ_CLIENT_ID`, `AZ_CLIENT_SECRET`, `AZ_TENANT_ID`, `AZ_USERNAME`, and `AZ_PASSWORD`.
-   These values are used to obtain a token for Microsoft Graph.
+2. Populate `.env` (or `config.toml`) with your Azure AD details. Add `AZ_AUTH_MODE`
+   or `auth_mode` to choose between:
+   - `app` &mdash; client credential flow using `AZ_CLIENT_SECRET`.
+   - `delegated` &mdash; username/password flow using `AZ_USERNAME` and `AZ_PASSWORD`.
+   At minimum the script expects `AZ_CLIENT_ID` and `AZ_TENANT_ID`, plus the
+   credentials required for the selected mode.
 3. Run the script:
    ```bash
    python email_analytics.py

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ tenant_id = "YOUR_AZURE_TENANT_ID"
 username = "YOUR_AZURE_USERNAME"
 password = "YOUR_AZURE_PASSWORD"
 base_url = "https://graph.microsoft.com/v1.0"
+auth_mode = "app"
 
 [analysis]
 top_n = 5

--- a/email_analytics.py
+++ b/email_analytics.py
@@ -66,16 +66,19 @@ def acquire_token(graph_cfg: dict) -> str:
     """Obtain an OAuth access token for Microsoft Graph."""
     authority = f"https://login.microsoftonline.com/{graph_cfg['tenant_id']}"
     scopes = ["https://graph.microsoft.com/.default"]
-    # Prefer Client Credentials flow if a client_secret is present
-    if graph_cfg.get('client_secret'):
+    auth_mode = graph_cfg.get('auth_mode', 'app')
+    if auth_mode == 'app':
+        if not graph_cfg.get('client_secret'):
+            raise RuntimeError('client_secret required for app auth_mode')
         app = msal.ConfidentialClientApplication(
             graph_cfg['client_id'],
             authority=authority,
             client_credential=graph_cfg['client_secret'],
         )
         result = app.acquire_token_for_client(scopes=scopes)
-    # Fallback to ROPC flow only if no client_secret
-    elif graph_cfg.get('username') and graph_cfg.get('password'):
+    elif auth_mode == 'delegated':
+        if not (graph_cfg.get('username') and graph_cfg.get('password')):
+            raise RuntimeError('username and password required for delegated auth_mode')
         app = msal.PublicClientApplication(graph_cfg['client_id'], authority=authority)
         result = app.acquire_token_by_username_password(
             graph_cfg['username'],
@@ -83,7 +86,7 @@ def acquire_token(graph_cfg: dict) -> str:
             scopes=scopes,
         )
     else:
-        raise RuntimeError('No valid authentication credentials found in config.')
+        raise RuntimeError(f"Unsupported auth_mode: {auth_mode}")
     if 'access_token' not in result:
         raise RuntimeError(f"Token acquisition failed: {result.get('error_description')}")
     return result['access_token']
@@ -120,6 +123,7 @@ def main():
                 "username":      os.getenv("AZ_USERNAME")      or os.getenv("MAIL_USER"),
                 "password":      os.getenv("AZ_PASSWORD")      or os.getenv("MAIL_PASSWORD"),
                 "base_url":      os.getenv("AZ_BASE_URL", "https://graph.microsoft.com/v1.0"),
+                "auth_mode":     os.getenv("AZ_AUTH_MODE", "app"),
             },
             "analysis": {
                 "top_n": int(os.getenv("ANALYSIS_TOP_N", "5")),


### PR DESCRIPTION
## Summary
- add `auth_mode` configuration to select between app and delegated flows
- update config and README to document auth_mode

## Testing
- `python -m py_compile email_analytics.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ab0ed1dc832fb4d323cf5d74cf77