### PR TITLE
Log HTTP response details on pagination errors

### DIFF
--- a/email_analytics.py
+++ b/email_analytics.py
@@ -55,7 +55,15 @@ async def async_paginate(client: AsyncClient, url: str, params: dict):
     items = []
     while url:
         resp = await client.get(url, params=params)
-        resp.raise_for_status()
+        try:
+            resp.raise_for_status()
+        except HTTPError:
+            try:
+                body = resp.json()
+            except ValueError:
+                body = resp.text
+            logger.error("HTTP request failed", url=str(resp.url), body=body)
+            raise
         data = resp.json()
         items.extend(data.get('value', []))
         url = data.get('@odata.nextLink')


### PR DESCRIPTION
## Summary
- Log HTTP request URL and response payload when `async_paginate` encounters an HTTP error
- Preserve retry behavior by re-raising the exception after logging

## Testing
- `python -m py_compile email_analytics.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ab0e628c832fa2a8e078fcc7b4ca