### PR TITLE
Handle missing or malformed tenant IDs in email analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ from `.env` (or the path specified by `ENV_FILE`).
 2. Populate `.env` with your Azure AD details. Add `AZ_AUTH_MODE` to choose between:
    - `app` &mdash; client credential flow using `AZ_CLIENT_SECRET`.
    - `delegated` &mdash; username/password flow using `AZ_USERNAME` and `AZ_PASSWORD`.
-   At minimum the script expects `CLIENT_ID` and `TENANT_ID`, plus the
-   credentials required for the selected mode.
+   At minimum the script expects `CLIENT_ID` and one of:
+   - `TENANT_ID` &mdash; a GUID for your Azure AD tenant; or
+   - `AUTHORITY` &mdash; a full authority URL such as `https://login.microsoftonline.com/organizations`.
+   If neither value is supplied the script automatically falls back to the
+   multi-tenant `common` endpoint.
 3. Run the script:
    ```bash
    python email_analytics.py


### PR DESCRIPTION
## Summary
- tolerate missing or malformed TENANT_ID by falling back to the multi-tenant 'common' endpoint
- allow explicit AUTHORITY override and document it

## Testing
- `python -m py_compile email_analytics.py`
- `TENANT_ID=invalid CLIENT_ID=dummy AZ_AUTH_MODE=app python email_analytics.py 2>&1 | tee /tmp/run.log` (fails: ProxyError)


------
https://chatgpt.com/codex/tasks/task_e_6893b94dcb58832fa15b942474b5d95b