### PR TITLE
Handle missing user id

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,10 @@
+[graph]
+client_id     = "4ed4dfba-881a-40e4-9190-ac0e90cb1796"
+client_secret = "RWm8Q~offFmH4d_CuU1YTeiOiyzz6018LBfc7bMX"
+tenant_id     = "10a53ce9-0d13-4702-876c-57bfa6433582"
+auth_mode     = "app"
+user_id       = "tmyers@hurricanefence.com"
+username      = "sowens@hurricanefence.com"
+password      = "#so3897#"
+base_url      = "https://graph.microsoft.com/v1.0"
+

--- a/email_analytics.py
+++ b/email_analytics.py
@@ -171,7 +171,13 @@ def main():
 
     logger.info("Starting pipeline", git_sha=cfg.get('meta', {}).get('git_sha', ''))
 
-    user_id = cfg['graph'].get('user_id') if cfg['graph'].get('client_secret') else None
+    # If running in app-only mode, default user_id to the configured username
+    if cfg['graph'].get('client_secret'):
+        user_id = cfg['graph'].get('user_id') or cfg['graph'].get('username')
+        if not user_id:
+            raise RuntimeError("user_id is required for app-only authentication")
+    else:
+        user_id = None
     emails = asyncio.run(fetch_inbox(cfg, user_id=user_id))
 
     # NLP embedding


### PR DESCRIPTION
## Summary
- configure user and auth defaults
- default to username when user id not provided

## Testing
- `python -m py_compile email_analytics.py`


------
https://chatgpt.com/codex/tasks/task_e_6893c431a274832fb6e9bdb54cb2a837